### PR TITLE
INT-5696-support-old-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 2.1.1 - 2022-10-12
+
+### Changed
+
+- Added support for original config values.
+
 ## 2.1.0 - 2022-10-11
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-microsoft-active-directory",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A JupiterOne Integration for ingesting data of the Microsoft Active Directory",
   "license": "MPL-2.0",
   "main": "src/index.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -59,6 +59,26 @@ export async function validateInvocation(
 ) {
   const { config } = context.instance;
 
+  // Support old config values.
+  // Added Oct 2022.
+  // All 4 instances are currently disabled.
+  if (!config.ldapUrl && config.clientUrl) {
+    config.ldapUrl = config.clientUrl;
+    delete config.clientUrl;
+  }
+  if (!config.baseDN && config.clientDomain) {
+    config.baseDN = config.clientDomain;
+    delete config.clientDomain;
+  }
+  if (!config.username && config.clientUsername) {
+    config.username = config.clientUsername;
+    delete config.clientUsername;
+  }
+  if (!config.password && config.clientPassword) {
+    config.password = config.clientPassword;
+    delete config.clientPassword;
+  }
+
   if (
     !config.ldapUrl ||
     !config.baseDN ||

--- a/src/validateInvocation.test.ts
+++ b/src/validateInvocation.test.ts
@@ -156,6 +156,21 @@ describe('#validateInvocation', () => {
           'Provider authentication failed at https://localhost/api/v1/some/endpoint?limit=1: 401 Unauthorized',
         );
       });
+
+      test('support old configField values', async () => {
+        const executionContext = createMockExecutionContext({
+          instanceConfig: {
+            clientUrl: 'http',
+            clientDomain: 'value',
+            clientUsername: 'testUsername',
+            clientPassword: 'test123',
+          } as unknown as IntegrationConfig,
+        });
+
+        await expect(
+          validateInvocation(executionContext),
+        ).resolves.toBeUndefined();
+      });
     });
   });
 });


### PR DESCRIPTION
# Description

Support old config values.

## Type of change

Please leave any irrelevant options unchecked.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

### General Development Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

### Integration Development Checklist:

Please leave any irrelevant options unchecked.

- [ ] I have checked for additional permissions required to call any new API
      endpoints, and have documented any additional permissions in
      `jupiterone.md`, where necessary.
- [ ] My changes properly paginate the target service provider's API
- [ ] My changes properly handle rate limiting of the target service provider's
      API
- [ ] My new integration step is instrumented to execute in the correct order
      using `dependsOn`
- [ ] I have referred to the
      [JupiterOne data model](https://github.com/JupiterOne/data-model/tree/main/src/schemas)
      to ensure that any new entities/relationships, and relevant properties,
      match the recommended model for this class of data
- [ ] I have updated the `CHANGELOG.md` file to describe my changes
- [ ] When changes include modifications to existing graph data ingestion, I've
      reviewed all existing managed questions referencing the entities,
      relationships, and their property names, to ensure those questions still
      function with my changes.
