### PR TITLE
DEVICE-120 - Added lastSeenOn, name, serial, isCriticalSystemObject, and lastLogon to Devices

### DIFF
--- a/src/steps/access/__snapshots__/index.test.ts.snap
+++ b/src/steps/access/__snapshots__/index.test.ts.snap
@@ -19,7 +19,7 @@ Object {
   "_key": "ad_device:CN=ActiveDirectory,OU=Domain Controllers,DC=activedirint,DC=com",
   "_type": "ad_device",
   "category": "computer",
-  "createdOn": 1647041559000,
+  "createdOn": Any<Number>,
   "deviceId": "CN=ActiveDirectory,OU=Domain Controllers,DC=activedirint,DC=com",
   "displayName": "ActiveDirectory",
   "isCriticalSystemObject": true,
@@ -31,7 +31,7 @@ Object {
   "operatingSystem": "Windows Server 2019 Datacenter",
   "operatingSystemVersion": "10.0 (17763)",
   "serial": null,
-  "updatedOn": 1649751405000,
+  "updatedOn": Any<Number>,
 }
 `;
 
@@ -42,11 +42,11 @@ Object {
   ],
   "_key": "ad_group:CN=Administrators,CN=Builtin,DC=activedirint,DC=com",
   "_type": "ad_group",
-  "createdOn": 1647041514000,
+  "createdOn": Any<Number>,
   "description": "Administrators have complete and unrestricted access to the computer/domain",
   "displayName": "Administrators",
   "name": "Administrators",
-  "updatedOn": 1647042471000,
+  "updatedOn": Any<Number>,
 }
 `;
 
@@ -58,11 +58,11 @@ Object {
   "_key": "ad_user:CN=activedir,CN=Users,DC=activedirint,DC=com",
   "_type": "ad_user",
   "active": true,
-  "createdOn": 1647041514000,
+  "createdOn": Any<Number>,
   "description": "Built-in account for administering the computer/domain",
   "displayName": "activedir",
   "name": "activedir",
-  "updatedOn": 1650392064000,
+  "updatedOn": Any<Number>,
   "username": "activedir",
 }
 `;

--- a/src/steps/access/__snapshots__/index.test.ts.snap
+++ b/src/steps/access/__snapshots__/index.test.ts.snap
@@ -24,7 +24,7 @@ Object {
   "displayName": "ActiveDirectory",
   "isCriticalSystemObject": true,
   "lastLogon": undefined,
-  "lastSeenOn": 1577836800000,
+  "lastSeenOn": Any<Number>,
   "make": null,
   "model": null,
   "name": "ActiveDirectory",

--- a/src/steps/access/__snapshots__/index.test.ts.snap
+++ b/src/steps/access/__snapshots__/index.test.ts.snap
@@ -1,0 +1,68 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`build-user-group-relationships 1`] = `
+Object {
+  "_class": "HAS",
+  "_fromEntityKey": "ad_group:CN=Group Policy Creator Owners,CN=Users,DC=activedirint,DC=com",
+  "_key": "ad_group:CN=Group Policy Creator Owners,CN=Users,DC=activedirint,DC=com|has|ad_user:CN=activedir,CN=Users,DC=activedirint,DC=com",
+  "_toEntityKey": "ad_user:CN=activedir,CN=Users,DC=activedirint,DC=com",
+  "_type": "ad_group_has_user",
+  "displayName": "HAS",
+}
+`;
+
+exports[`fetch-devices 1`] = `
+Object {
+  "_class": Array [
+    "Device",
+  ],
+  "_key": "ad_device:CN=ActiveDirectory,OU=Domain Controllers,DC=activedirint,DC=com",
+  "_type": "ad_device",
+  "category": "computer",
+  "createdOn": 1647041559000,
+  "deviceId": "CN=ActiveDirectory,OU=Domain Controllers,DC=activedirint,DC=com",
+  "displayName": "ActiveDirectory",
+  "isCriticalSystemObject": true,
+  "lastLogon": undefined,
+  "lastSeenOn": 1577836800000,
+  "make": null,
+  "model": null,
+  "name": "ActiveDirectory",
+  "operatingSystem": "Windows Server 2019 Datacenter",
+  "operatingSystemVersion": "10.0 (17763)",
+  "serial": null,
+  "updatedOn": 1649751405000,
+}
+`;
+
+exports[`fetch-groups 1`] = `
+Object {
+  "_class": Array [
+    "UserGroup",
+  ],
+  "_key": "ad_group:CN=Administrators,CN=Builtin,DC=activedirint,DC=com",
+  "_type": "ad_group",
+  "createdOn": 1647041514000,
+  "description": "Administrators have complete and unrestricted access to the computer/domain",
+  "displayName": "Administrators",
+  "name": "Administrators",
+  "updatedOn": 1647042471000,
+}
+`;
+
+exports[`fetch-users 1`] = `
+Object {
+  "_class": Array [
+    "User",
+  ],
+  "_key": "ad_user:CN=activedir,CN=Users,DC=activedirint,DC=com",
+  "_type": "ad_user",
+  "active": true,
+  "createdOn": 1647041514000,
+  "description": "Built-in account for administering the computer/domain",
+  "displayName": "activedir",
+  "name": "activedir",
+  "updatedOn": 1650392064000,
+  "username": "activedir",
+}
+`;

--- a/src/steps/access/converter.ts
+++ b/src/steps/access/converter.ts
@@ -4,6 +4,7 @@ import {
   Entity,
   RelationshipClass,
   Relationship,
+  parseTimePropertyValue,
 } from '@jupiterone/integration-sdk-core';
 
 import { Entities } from '../constants';
@@ -59,6 +60,11 @@ export function createGroupEntity(group: ActiveDirectoryGroup): Entity {
 
 export function createDeviceEntity(computer: ActiveDirectoryComputer): Entity {
   const id = `ad_device:${computer.dn}`;
+  const lastLogon =
+    isNaN(Number(computer.lastLogonTimestamp)) ||
+    Number(computer.lastLogonTimestamp) == 0
+      ? undefined
+      : parseTimePropertyValue(Number(computer.lastLogonTimestamp), 'ms');
 
   return createIntegrationEntity({
     entityData: {
@@ -67,15 +73,19 @@ export function createDeviceEntity(computer: ActiveDirectoryComputer): Entity {
         _type: Entities.DEVICE._type,
         _class: Entities.DEVICE._class,
         _key: id,
+        name: computer.name,
         deviceId: computer.dn,
-        category: computer.instanceType,
-        make: 'N/A',
-        model: 'N/A',
-        serial: 'N/A',
+        category: 'computer', // client.iterateDevices is specifically filtering on "COMPUTER"
+        make: null,
+        model: null,
+        serial: null,
         operatingSystem: computer.operatingSystem,
         operatingSystemVersion: computer.operatingSystemVersion,
+        isCriticalSystemObject: computer.isCriticalSystemObject == 'TRUE',
+        lastLogon,
         createdOn: parseLdapDatetime(computer.whenCreated),
         updatedOn: parseLdapDatetime(computer.whenChanged),
+        lastSeenOn: parseTimePropertyValue(new Date()), // Because we are doing the scanning ourselves with iterateDevices, the current time is the lassSeenOn value.
       },
     },
   });

--- a/src/steps/access/index.test.ts
+++ b/src/steps/access/index.test.ts
@@ -31,5 +31,7 @@ test('fetch-devices', async () => {
   const stepConfig = buildStepTestConfigForStep(Steps.DEVICES);
   const stepResult = await executeStepWithDependencies(stepConfig);
   expect(stepResult).toMatchStepMetadata(stepConfig);
-  expect(omit(stepResult.collectedEntities[0], ['_rawData'])).toMatchSnapshot();
+  expect(omit(stepResult.collectedEntities[0], ['_rawData'])).toMatchSnapshot({
+    lastSeenOn: expect.any(Number),
+  });
 });

--- a/src/steps/access/index.test.ts
+++ b/src/steps/access/index.test.ts
@@ -1,22 +1,35 @@
 import { executeStepWithDependencies } from '@jupiterone/integration-sdk-testing';
 import { buildStepTestConfigForStep } from '../../../test/config';
 import { Steps } from '../constants';
+import { omit } from 'lodash';
+
+beforeAll(() => jest.useFakeTimers().setSystemTime(new Date('2020-01-01')));
+afterAll(() => jest.useRealTimers());
 
 test('fetch-users', async () => {
   const stepConfig = buildStepTestConfigForStep(Steps.USERS);
   const stepResult = await executeStepWithDependencies(stepConfig);
-
   expect(stepResult).toMatchStepMetadata(stepConfig);
+  expect(omit(stepResult.collectedEntities[0], ['_rawData'])).toMatchSnapshot();
 });
 
 test('fetch-groups', async () => {
   const stepConfig = buildStepTestConfigForStep(Steps.GROUPS);
   const stepResult = await executeStepWithDependencies(stepConfig);
   expect(stepResult).toMatchStepMetadata(stepConfig);
+  expect(omit(stepResult.collectedEntities[0], ['_rawData'])).toMatchSnapshot();
 });
 
 test('build-user-group-relationships', async () => {
   const stepConfig = buildStepTestConfigForStep(Steps.GROUP_USER_RELATIONSHIPS);
   const stepResult = await executeStepWithDependencies(stepConfig);
   expect(stepResult).toMatchStepMetadata(stepConfig);
+  expect(stepResult.collectedRelationships[0]).toMatchSnapshot();
+});
+
+test('fetch-devices', async () => {
+  const stepConfig = buildStepTestConfigForStep(Steps.DEVICES);
+  const stepResult = await executeStepWithDependencies(stepConfig);
+  expect(stepResult).toMatchStepMetadata(stepConfig);
+  expect(omit(stepResult.collectedEntities[0], ['_rawData'])).toMatchSnapshot();
 });

--- a/src/steps/access/index.test.ts
+++ b/src/steps/access/index.test.ts
@@ -10,14 +10,20 @@ test('fetch-users', async () => {
   const stepConfig = buildStepTestConfigForStep(Steps.USERS);
   const stepResult = await executeStepWithDependencies(stepConfig);
   expect(stepResult).toMatchStepMetadata(stepConfig);
-  expect(omit(stepResult.collectedEntities[0], ['_rawData'])).toMatchSnapshot();
+  expect(omit(stepResult.collectedEntities[0], ['_rawData'])).toMatchSnapshot({
+    createdOn: expect.any(Number),
+    updatedOn: expect.any(Number),
+  });
 });
 
 test('fetch-groups', async () => {
   const stepConfig = buildStepTestConfigForStep(Steps.GROUPS);
   const stepResult = await executeStepWithDependencies(stepConfig);
   expect(stepResult).toMatchStepMetadata(stepConfig);
-  expect(omit(stepResult.collectedEntities[0], ['_rawData'])).toMatchSnapshot();
+  expect(omit(stepResult.collectedEntities[0], ['_rawData'])).toMatchSnapshot({
+    createdOn: expect.any(Number),
+    updatedOn: expect.any(Number),
+  });
 });
 
 test('build-user-group-relationships', async () => {
@@ -33,5 +39,7 @@ test('fetch-devices', async () => {
   expect(stepResult).toMatchStepMetadata(stepConfig);
   expect(omit(stepResult.collectedEntities[0], ['_rawData'])).toMatchSnapshot({
     lastSeenOn: expect.any(Number),
+    createdOn: expect.any(Number),
+    updatedOn: expect.any(Number),
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,10 +24,13 @@ export interface ActiveDirectoryComputer {
   dn: string;
   cn: string;
   objectGUID: string;
+  objectCategory: string;
   name: string;
   instanceType: string;
   operatingSystem: string;
   operatingSystemVersion: string;
+  isCriticalSystemObject: string;
+  lastLogonTimestamp: string;
   whenCreated: string;
   whenChanged: string;
 }


### PR DESCRIPTION
# Description

Added lastSeenOn, name, serial, isCriticalSystemObject, and lastLogon to Devices. Also made make, model, and serialNumber null for clarity.

## Type of change

Please leave any irrelevant options unchecked.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

### General Development Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Integration Development Checklist:

Please leave any irrelevant options unchecked.

- [x] I have checked for additional permissions required to call any new API
      endpoints, and have documented any additional permissions in
      `jupiterone.md`, where necessary.
- [x] My changes properly paginate the target service provider's API
- [x] My changes properly handle rate limiting of the target service provider's
      API
- [x] My new integration step is instrumented to execute in the correct order
      using `dependsOn`
- [x] I have referred to the
      [JupiterOne data model](https://github.com/JupiterOne/data-model/tree/main/src/schemas)
      to ensure that any new entities/relationships, and relevant properties,
      match the recommended model for this class of data
- [ ] I have updated the `CHANGELOG.md` file to describe my changes
- [ ] When changes include modifications to existing graph data ingestion, I've
      reviewed all existing managed questions referencing the entities,
      relationships, and their property names, to ensure those questions still
      function with my changes.
